### PR TITLE
congressional rep page tweaks

### DIFF
--- a/client/components/congress/repBio.js
+++ b/client/components/congress/repBio.js
@@ -26,7 +26,7 @@ const RepBio = ({ bio, google }) => {
 
   return (
     <div className="rep-bio">
-      <img src={google.photoUrl} alt={bio.name} />
+      <img src={google.photoUrl} alt={bio.name} style={{maxHeight:"300px"}} />
       <Title>{ party }</Title>
       <Title>{ title }</Title>
       <h3>{ first }</h3>

--- a/client/components/congress/repDisplay.js
+++ b/client/components/congress/repDisplay.js
@@ -1,4 +1,3 @@
-import _ from 'underscore';
 import shortid from 'shortid';
 
 import Box from 'grommet/components/Box';
@@ -60,7 +59,7 @@ class RepDisplay extends Component {
     const { reps, propublica } = this.props;
 
     // this allows the user to select a rep
-    const tabArray = _.map(propublica, rep =>
+    const tabArray = reps.map(rep =>
       <Tab
         key={shortid.generate()}
         title={rep.name || ''}


### PR DESCRIPTION
rep tabs now render in a consistent order, rep image on null is no longer oversized